### PR TITLE
Fix the issue: Kafka's vote thread is not set

### DIFF
--- a/ipper/kafka/wiki.py
+++ b/ipper/kafka/wiki.py
@@ -176,7 +176,7 @@ def enrich_kip_info(body_html: str, kip_dict: dict[str, list[str] | str | int]) 
 
             discussion_processed = True
 
-        elif not vote_processed and "voting thread" in para.text.lower():
+        elif not vote_processed and "vote thread" in para.text.lower():
             link = para.find("a")
             href = link.get("href") if link else None
 


### PR DESCRIPTION
Fix this issue:
<img width="967" height="151" alt="image" src="https://github.com/user-attachments/assets/a3d028ca-a2d2-41ff-b4b5-462743e56a86" />

According to this:

<img width="847" height="192" alt="image" src="https://github.com/user-attachments/assets/3bfb882a-0adb-4e3a-bc1b-fb1b92c35f9f" />

